### PR TITLE
refactor: use `recoil` instead of `Context`

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -21,7 +21,14 @@
     "react/react-in-jsx-scope": "off",
     "camelcase": "error",
     "spaced-comment": "error",
-    "no-duplicate-imports": "error"
+    "no-duplicate-imports": "error",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": [
+      "warn",
+      {
+        "additionalHooks": "(useRecoilCallback|useRecoilTransaction_UNSTABLE)"
+      }
+    ]
   },
   "settings": {
     "react": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -25,6 +25,7 @@
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.4.0",
         "react-scripts": "5.0.1",
+        "recoil": "^0.7.5",
         "socket.io-client": "^4.5.2",
         "unique-names-generator": "^4.7.1",
         "web-vitals": "^2.1.4"
@@ -9214,6 +9215,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -14945,6 +14951,25 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.5.tgz",
+      "integrity": "sha512-GVShsj5+M/2GULWBs5WBJGcsNis/d3YvDiaKjYh3mLKXftjtmk9kfaQ8jwjoIXySCwn8/RhgJ4Sshwgzj2UpFA==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/recursive-readdir": {
@@ -24220,6 +24245,11 @@
         "duplexer": "^0.1.2"
       }
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -28355,6 +28385,14 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "recoil": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.5.tgz",
+      "integrity": "sha512-GVShsj5+M/2GULWBs5WBJGcsNis/d3YvDiaKjYh3mLKXftjtmk9kfaQ8jwjoIXySCwn8/RhgJ4Sshwgzj2UpFA==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "recursive-readdir": {

--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.4.0",
     "react-scripts": "5.0.1",
+    "recoil": "^0.7.5",
     "socket.io-client": "^4.5.2",
     "unique-names-generator": "^4.7.1",
     "web-vitals": "^2.1.4"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useRecoilValue } from "recoil";
 import { BrowserRouter, Route, Routes, Navigate } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import { CssVarsProvider } from "@mui/joy/styles";
@@ -8,8 +7,10 @@ import { Container } from "@mui/joy";
 import Home from "./components/Home/Home";
 import Call from "./components/Call/Call";
 
+import useJoinedRoom from "./hooks/useJoinedRoom";
+import useCallEnded from "./hooks/useCallEnded";
+
 import madoTheme from "./madoTheme";
-import { callEndedAtom, joinedRoomAtom } from "./atoms";
 
 const useStyles = makeStyles(() => ({
   wrapper: {
@@ -23,8 +24,8 @@ const useStyles = makeStyles(() => ({
 const App = (): JSX.Element => {
   const classes = useStyles();
 
-  const callEnded = useRecoilValue(callEndedAtom);
-  const joinedRoom = useRecoilValue(joinedRoomAtom);
+  const { callEnded } = useCallEnded();
+  const { joinedRoom } = useJoinedRoom();
 
   return (
     <CssVarsProvider theme={madoTheme}>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useRecoilValue } from "recoil";
 import { BrowserRouter, Route, Routes, Navigate } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import { CssVarsProvider } from "@mui/joy/styles";
@@ -8,7 +9,7 @@ import Home from "./components/Home/Home";
 import Call from "./components/Call/Call";
 
 import madoTheme from "./madoTheme";
-import { useSocketContext } from "./hooks/useSocketContext";
+import { callEndedAtom, joinedRoomAtom } from "./atoms";
 
 const useStyles = makeStyles(() => ({
   wrapper: {
@@ -22,7 +23,8 @@ const useStyles = makeStyles(() => ({
 const App = (): JSX.Element => {
   const classes = useStyles();
 
-  const { callEnded, joinedRoom } = useSocketContext();
+  const callEnded = useRecoilValue(callEndedAtom);
+  const joinedRoom = useRecoilValue(joinedRoomAtom);
 
   return (
     <CssVarsProvider theme={madoTheme}>

--- a/client/src/atoms.ts
+++ b/client/src/atoms.ts
@@ -1,0 +1,72 @@
+import { RecoilState, atom } from "recoil";
+import {
+  uniqueNamesGenerator,
+  adjectives,
+  animals,
+} from "unique-names-generator";
+import { Call } from "./types";
+
+const randomRoomName = uniqueNamesGenerator({
+  dictionaries: [adjectives, animals],
+  separator: "",
+  style: "capital",
+});
+
+export const serverLoadingAtom = atom({
+  key: "serverLoading",
+  default: true,
+});
+
+export const streamAtom: RecoilState<MediaStream> = atom({
+  key: "stream",
+});
+
+export const meAtom = atom({
+  key: "me",
+  default: "",
+});
+
+export const callAtom: RecoilState<Call> = atom({
+  key: "call",
+  default: {
+    isRecievedCall: false,
+    from: "",
+    name: "",
+    isVideo: true,
+  },
+});
+
+export const joinedRoomAtom = atom({
+  key: "joinedRoom",
+  default: false,
+});
+
+export const callEndedAtom = atom({
+  key: "callEnded",
+  default: false,
+});
+
+export const roomNameAtom = atom({
+  key: "roomName",
+  default: randomRoomName,
+});
+
+export const nameAtom = atom({
+  key: "name",
+  default: "",
+});
+
+export const isAudioAtom = atom({
+  key: "isAudio",
+  default: true,
+});
+
+export const isVideoAtom = atom({
+  key: "isVideo",
+  default: true,
+});
+
+export const isCallerMutedAtom = atom({
+  key: "isCallerMuted",
+  default: false,
+});

--- a/client/src/atoms.ts
+++ b/client/src/atoms.ts
@@ -17,8 +17,9 @@ export const serverLoadingAtom = atom({
   default: true,
 });
 
-export const streamAtom: RecoilState<MediaStream> = atom({
+export const streamAtom: RecoilState<MediaStream | undefined> = atom({
   key: "stream",
+  default: undefined,
 });
 
 export const meAtom = atom({

--- a/client/src/components/Call/Call.tsx
+++ b/client/src/components/Call/Call.tsx
@@ -80,10 +80,6 @@ const Call = (): JSX.Element => {
     peer.connect(call.from, { metadata: { isVideo } });
   }, [isVideo]);
 
-  useEffect(() => {
-    if (joinedRoom && myVideo.current) myVideo.current!.srcObject = stream!;
-  }, [joinedRoom]);
-
   return (
     <div className={classes.videoContainer}>
       {joinedRoom && !callEnded && (

--- a/client/src/components/Call/Call.tsx
+++ b/client/src/components/Call/Call.tsx
@@ -27,6 +27,7 @@ const Call = (): JSX.Element => {
             textColor="white"
             level="h5"
             className={classes.callerName}
+            sx={{ zIndex: 2500 }}
           >
             {call.name}
           </Typography>

--- a/client/src/components/Call/Call.tsx
+++ b/client/src/components/Call/Call.tsx
@@ -1,32 +1,33 @@
 import React, { useEffect } from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
 import { Avatar, Typography } from "@mui/joy";
 
 import VideoControls from "../VideoControls/VideoControls";
-import { useSocketContext } from "../../hooks/useSocketContext";
+
 import useStyles from "./styles";
-import {
-  callAtom,
-  callEndedAtom,
-  isCallerMutedAtom,
-  isVideoAtom,
-  joinedRoomAtom,
-  nameAtom,
-  streamAtom,
-} from "../../atoms";
+
 import { peer, socket } from "../../utils";
+
+import { useSocketContext } from "../../hooks/useSocketContext";
+
+import useCall from "../../hooks/useCall";
+import useName from "../../hooks/useName";
+import useIsVideo from "../../hooks/isVideo";
+import useStream from "../../hooks/useStream";
+import useCallEnded from "../../hooks/useCallEnded";
+import useJoinedRoom from "../../hooks/useJoinedRoom";
+import useIsCallerMuted from "../../hooks/isCallerMuted";
 
 const Call = (): JSX.Element => {
   const { myVideo, userVideo } = useSocketContext();
 
-  const [call, setCall] = useRecoilState(callAtom);
+  const { call, setCall } = useCall();
+  const { callEnded } = useCallEnded();
 
-  const callEnded = useRecoilValue(callEndedAtom);
-  const isCallerMuted = useRecoilValue(isCallerMutedAtom);
-  const isVideo = useRecoilValue(isVideoAtom);
-  const stream = useRecoilValue(streamAtom);
-  const joinedRoom = useRecoilValue(joinedRoomAtom);
-  const name = useRecoilValue(nameAtom);
+  const { isCallerMuted } = useIsCallerMuted();
+  const { isVideo } = useIsVideo();
+  const { stream } = useStream();
+  const { joinedRoom } = useJoinedRoom();
+  const { name } = useName();
 
   const classes = useStyles();
 

--- a/client/src/components/Home/Home.tsx
+++ b/client/src/components/Home/Home.tsx
@@ -1,19 +1,62 @@
 import React, { useEffect } from "react";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { Grid } from "@material-ui/core";
 import { useNavigate, useParams } from "react-router-dom";
 
 import Options from "./Options/Options";
 import Navbar from "../Navbar/Navbar";
 import HomeVideoPlayer from "./HomeVideoPlayer/HomeVideoPlayer";
-import { useSocketContext } from "../../hooks/useSocketContext";
 import useStyles from "./styles";
+import {
+  callEndedAtom,
+  isVideoAtom,
+  joinedRoomAtom,
+  meAtom,
+  serverLoadingAtom,
+  streamAtom,
+} from "../../atoms";
+import { useSocketContext } from "../../hooks/useSocketContext";
+import { peer, socket } from "../../utils";
 
 const Home = (): JSX.Element => {
   const classes = useStyles();
   const navigate = useNavigate();
   const { id } = useParams();
 
-  const { joinedRoom, callEnded } = useSocketContext();
+  const { myVideo } = useSocketContext();
+
+  const stream = useRecoilValue(streamAtom);
+  const isVideo = useRecoilValue(isVideoAtom);
+  const callEnded = useRecoilValue(callEndedAtom);
+  const joinedRoom = useRecoilValue(joinedRoomAtom);
+
+  const setMe = useSetRecoilState(meAtom);
+  const setStream = useSetRecoilState(streamAtom);
+  const setServerLoading = useSetRecoilState(serverLoadingAtom);
+
+  useEffect(() => {
+    navigator.mediaDevices
+      .getUserMedia({ video: true, audio: true })
+      .then((currentStream) => {
+        setStream(currentStream);
+        myVideo.current!.srcObject = currentStream;
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+
+    socket.on("connection", () => setServerLoading(false));
+
+    peer.on("open", (myId) => setMe(myId));
+
+    peer.on("error", (err) => {
+      console.log("Error: ", err);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (myVideo.current) myVideo.current!.srcObject = stream!;
+  }, [isVideo]);
 
   useEffect(() => {
     if (joinedRoom && !callEnded) navigate("/call");

--- a/client/src/components/Home/Home.tsx
+++ b/client/src/components/Home/Home.tsx
@@ -1,15 +1,20 @@
 import React, { useEffect } from "react";
-import { useSetRecoilState } from "recoil";
 import { Grid } from "@material-ui/core";
 import { useParams } from "react-router-dom";
 
 import Options from "./Options/Options";
 import Navbar from "../Navbar/Navbar";
 import HomeVideoPlayer from "./HomeVideoPlayer/HomeVideoPlayer";
+
 import useStyles from "./styles";
-import { meAtom, serverLoadingAtom, streamAtom } from "../../atoms";
-import { useSocketContext } from "../../hooks/useSocketContext";
+
 import { peer, socket } from "../../utils";
+
+import { useSocketContext } from "../../hooks/useSocketContext";
+
+import useMe from "../../hooks/useMe";
+import useStream from "../../hooks/useStream";
+import useServerLoading from "../../hooks/useServerLoading";
 
 const Home = (): JSX.Element => {
   const classes = useStyles();
@@ -17,9 +22,9 @@ const Home = (): JSX.Element => {
 
   const { myVideo } = useSocketContext();
 
-  const setMe = useSetRecoilState(meAtom);
-  const setStream = useSetRecoilState(streamAtom);
-  const setServerLoading = useSetRecoilState(serverLoadingAtom);
+  const { setMe } = useMe();
+  const { setStream } = useStream();
+  const { setServerLoading } = useServerLoading();
 
   useEffect(() => {
     navigator.mediaDevices

--- a/client/src/components/Home/Home.tsx
+++ b/client/src/components/Home/Home.tsx
@@ -1,34 +1,21 @@
 import React, { useEffect } from "react";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { Grid } from "@material-ui/core";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 import Options from "./Options/Options";
 import Navbar from "../Navbar/Navbar";
 import HomeVideoPlayer from "./HomeVideoPlayer/HomeVideoPlayer";
 import useStyles from "./styles";
-import {
-  callEndedAtom,
-  isVideoAtom,
-  joinedRoomAtom,
-  meAtom,
-  serverLoadingAtom,
-  streamAtom,
-} from "../../atoms";
+import { meAtom, serverLoadingAtom, streamAtom } from "../../atoms";
 import { useSocketContext } from "../../hooks/useSocketContext";
 import { peer, socket } from "../../utils";
 
 const Home = (): JSX.Element => {
   const classes = useStyles();
-  const navigate = useNavigate();
   const { id } = useParams();
 
   const { myVideo } = useSocketContext();
-
-  const stream = useRecoilValue(streamAtom);
-  const isVideo = useRecoilValue(isVideoAtom);
-  const callEnded = useRecoilValue(callEndedAtom);
-  const joinedRoom = useRecoilValue(joinedRoomAtom);
 
   const setMe = useSetRecoilState(meAtom);
   const setStream = useSetRecoilState(streamAtom);
@@ -44,23 +31,15 @@ const Home = (): JSX.Element => {
       .catch((error) => {
         console.log(error);
       });
-
-    socket.on("connection", () => setServerLoading(false));
-
-    peer.on("open", (myId) => setMe(myId));
-
-    peer.on("error", (err) => {
-      console.log("Error: ", err);
-    });
   }, []);
 
-  useEffect(() => {
-    if (myVideo.current) myVideo.current!.srcObject = stream!;
-  }, [isVideo]);
+  socket.on("connection", () => setServerLoading(false));
 
-  useEffect(() => {
-    if (joinedRoom && !callEnded) navigate("/call");
-  }, [joinedRoom]);
+  peer.on("open", (myId) => setMe(myId));
+
+  peer.on("error", (err) => {
+    console.log("Error: ", err);
+  });
 
   return (
     <>

--- a/client/src/components/Home/HomeVideoPlayer/HomeVideoPlayer.tsx
+++ b/client/src/components/Home/HomeVideoPlayer/HomeVideoPlayer.tsx
@@ -4,11 +4,16 @@ import { Avatar } from "@mui/joy";
 import VideoControls from "../../VideoControls/VideoControls";
 import { useSocketContext } from "../../../hooks/useSocketContext";
 import useStyles from "./styles";
+import { useRecoilValue } from "recoil";
+import { isVideoAtom, streamAtom } from "../../../atoms";
 
 const HomeVideoPlayer = () => {
   const classes = useStyles();
 
-  const { myVideo, isVideo, stream } = useSocketContext();
+  const { myVideo } = useSocketContext();
+
+  const isVideo = useRecoilValue(isVideoAtom);
+  const stream = useRecoilValue(streamAtom);
 
   return (
     <>

--- a/client/src/components/Home/HomeVideoPlayer/HomeVideoPlayer.tsx
+++ b/client/src/components/Home/HomeVideoPlayer/HomeVideoPlayer.tsx
@@ -2,18 +2,21 @@ import React from "react";
 import { Avatar } from "@mui/joy";
 
 import VideoControls from "../../VideoControls/VideoControls";
-import { useSocketContext } from "../../../hooks/useSocketContext";
+
 import useStyles from "./styles";
-import { useRecoilValue } from "recoil";
-import { isVideoAtom, streamAtom } from "../../../atoms";
+
+import { useSocketContext } from "../../../hooks/useSocketContext";
+
+import useIsVideo from "../../../hooks/isVideo";
+import useStream from "../../../hooks/useStream";
 
 const HomeVideoPlayer = () => {
   const classes = useStyles();
 
   const { myVideo } = useSocketContext();
 
-  const isVideo = useRecoilValue(isVideoAtom);
-  const stream = useRecoilValue(streamAtom);
+  const { isVideo } = useIsVideo();
+  const { stream } = useStream();
 
   return (
     <>

--- a/client/src/components/Home/Options/Options.tsx
+++ b/client/src/components/Home/Options/Options.tsx
@@ -5,6 +5,7 @@ import { LoadingButton } from "@mui/lab";
 import { Typography } from "@mui/joy";
 import { ContentCopy, Phone } from "@mui/icons-material";
 import CopyToClipboard from "react-copy-to-clipboard";
+import { useNavigate } from "react-router-dom";
 
 import { useSocketContext } from "../../../hooks/useSocketContext";
 import TextField from "./TextField/TextField";
@@ -33,10 +34,11 @@ const Options = ({ roomId }: { roomId: string }): JSX.Element => {
   const { myVideo, userVideo } = useSocketContext();
   const [roomToJoin, setRoomToJoin] = useState(roomId || roomName);
   const classes = useStyles();
+  const navigate = useNavigate();
 
   const joinRoom = (room: string): void => {
     setJoinedRoom(true);
-
+    navigate("/call");
     socket.emit("join-room", room, me);
 
     socket.on("joined-room", () => {

--- a/client/src/components/Home/Options/Options.tsx
+++ b/client/src/components/Home/Options/Options.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { Grid, Paper } from "@material-ui/core";
 import { LoadingButton } from "@mui/lab";
 import { Typography } from "@mui/joy";
@@ -7,29 +6,30 @@ import { ContentCopy, Phone } from "@mui/icons-material";
 import CopyToClipboard from "react-copy-to-clipboard";
 import { useNavigate } from "react-router-dom";
 
-import { useSocketContext } from "../../../hooks/useSocketContext";
 import TextField from "./TextField/TextField";
 
 import useStyles from "./styles";
-import {
-  callAtom,
-  joinedRoomAtom,
-  meAtom,
-  nameAtom,
-  roomNameAtom,
-  serverLoadingAtom,
-  streamAtom,
-} from "../../../atoms";
+
 import { socket, peer } from "../../../utils";
 
+import { useSocketContext } from "../../../hooks/useSocketContext";
+
+import useMe from "../../../hooks/useMe";
+import useCall from "../../../hooks/useCall";
+import useName from "../../../hooks/useName";
+import useStream from "../../../hooks/useStream";
+import useRoomName from "../../../hooks/useRoomName";
+import useJoinedRoom from "../../../hooks/useJoinedRoom";
+import useServerLoading from "../../../hooks/useServerLoading";
+
 const Options = ({ roomId }: { roomId: string }): JSX.Element => {
-  const [joinedRoom, setJoinedRoom] = useRecoilState(joinedRoomAtom);
-  const [name, setName] = useRecoilState(nameAtom);
-  const serverLoading = useRecoilValue(serverLoadingAtom);
-  const me = useRecoilValue(meAtom);
-  const stream = useRecoilValue(streamAtom);
-  const roomName = useRecoilValue(roomNameAtom);
-  const setCall = useSetRecoilState(callAtom);
+  const { joinedRoom, setJoinedRoom } = useJoinedRoom();
+  const { name, setName } = useName();
+  const { serverLoading } = useServerLoading();
+  const { me } = useMe();
+  const { stream } = useStream();
+  const { roomName } = useRoomName();
+  const { setCall } = useCall();
 
   const { myVideo, userVideo } = useSocketContext();
   const [roomToJoin, setRoomToJoin] = useState(roomId || roomName);

--- a/client/src/components/VideoControls/VideoControls.tsx
+++ b/client/src/components/VideoControls/VideoControls.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { Grid } from "@material-ui/core";
 import { IconButton } from "@mui/joy";
@@ -13,6 +13,7 @@ import {
 } from "@mui/icons-material";
 
 import useStyles from "./styles";
+import { useSocketContext } from "../../hooks/useSocketContext";
 import {
   callEndedAtom,
   isAudioAtom,
@@ -25,6 +26,8 @@ import {
 const VideoControls = (): JSX.Element => {
   const classes = useStyles();
 
+  const { myVideo } = useSocketContext();
+
   const [isCallerMuted, setIsCallerMuted] = useRecoilState(isCallerMutedAtom);
   const [isAudio, setIsAudio] = useRecoilState(isAudioAtom);
   const [isVideo, setIsVideo] = useRecoilState(isVideoAtom);
@@ -33,6 +36,10 @@ const VideoControls = (): JSX.Element => {
   const stream = useRecoilValue(streamAtom);
 
   const setCallEnded = useSetRecoilState(callEndedAtom);
+
+  useEffect(() => {
+    if (myVideo.current) myVideo.current!.srcObject = stream!;
+  }, [isVideo]);
 
   const handleAudio = (): void => {
     stream!.getAudioTracks()[0].enabled = !isAudio;

--- a/client/src/components/VideoControls/VideoControls.tsx
+++ b/client/src/components/VideoControls/VideoControls.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from "react";
-import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { Grid } from "@material-ui/core";
 import { IconButton } from "@mui/joy";
 import {
@@ -14,28 +13,25 @@ import {
 
 import useStyles from "./styles";
 import { useSocketContext } from "../../hooks/useSocketContext";
-import {
-  callEndedAtom,
-  isAudioAtom,
-  isCallerMutedAtom,
-  isVideoAtom,
-  joinedRoomAtom,
-  streamAtom,
-} from "../../atoms";
+
+import useIsVideo from "../../hooks/isVideo";
+import useStream from "../../hooks/useStream";
+import useIsAudio from "../../hooks/useIsAudio";
+import useCallEnded from "../../hooks/useCallEnded";
+import useJoinedRoom from "../../hooks/useJoinedRoom";
+import useIsCallerMuted from "../../hooks/isCallerMuted";
 
 const VideoControls = (): JSX.Element => {
   const classes = useStyles();
 
   const { myVideo } = useSocketContext();
 
-  const [isCallerMuted, setIsCallerMuted] = useRecoilState(isCallerMutedAtom);
-  const [isAudio, setIsAudio] = useRecoilState(isAudioAtom);
-  const [isVideo, setIsVideo] = useRecoilState(isVideoAtom);
-
-  const joinedRoom = useRecoilValue(joinedRoomAtom);
-  const stream = useRecoilValue(streamAtom);
-
-  const setCallEnded = useSetRecoilState(callEndedAtom);
+  const { isCallerMuted, setIsCallerMuted } = useIsCallerMuted();
+  const { isAudio, setIsAudio } = useIsAudio();
+  const { isVideo, setIsVideo } = useIsVideo();
+  const { joinedRoom } = useJoinedRoom();
+  const { stream } = useStream();
+  const { setCallEnded } = useCallEnded();
 
   useEffect(() => {
     if (myVideo.current) myVideo.current!.srcObject = stream!;

--- a/client/src/components/VideoControls/VideoControls.tsx
+++ b/client/src/components/VideoControls/VideoControls.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { Grid } from "@material-ui/core";
 import { IconButton } from "@mui/joy";
 import {
@@ -11,24 +12,27 @@ import {
   VolumeUp,
 } from "@mui/icons-material";
 
-import { useSocketContext } from "../../hooks/useSocketContext";
-
 import useStyles from "./styles";
+import {
+  callEndedAtom,
+  isAudioAtom,
+  isCallerMutedAtom,
+  isVideoAtom,
+  joinedRoomAtom,
+  streamAtom,
+} from "../../atoms";
 
 const VideoControls = (): JSX.Element => {
   const classes = useStyles();
 
-  const {
-    stream,
-    isAudio,
-    setIsAudio,
-    isVideo,
-    setIsVideo,
-    isCallerMuted,
-    setIsCallerMuted,
-    leaveCall,
-    joinedRoom,
-  } = useSocketContext();
+  const [isCallerMuted, setIsCallerMuted] = useRecoilState(isCallerMutedAtom);
+  const [isAudio, setIsAudio] = useRecoilState(isAudioAtom);
+  const [isVideo, setIsVideo] = useRecoilState(isVideoAtom);
+
+  const joinedRoom = useRecoilValue(joinedRoomAtom);
+  const stream = useRecoilValue(streamAtom);
+
+  const setCallEnded = useSetRecoilState(callEndedAtom);
 
   const handleAudio = (): void => {
     stream!.getAudioTracks()[0].enabled = !isAudio;
@@ -38,6 +42,11 @@ const VideoControls = (): JSX.Element => {
   const handleVideo = (): void => {
     stream!.getVideoTracks()[0].enabled = !isVideo;
     setIsVideo((prevVideo) => !prevVideo);
+  };
+
+  const leaveCall = (): void => {
+    setCallEnded(true);
+    window.location.reload();
   };
 
   return (

--- a/client/src/context/SocketContext.tsx
+++ b/client/src/context/SocketContext.tsx
@@ -1,13 +1,22 @@
-import React, { createContext, useState, useRef, useEffect } from "react";
+import React, { createContext, useRef, useEffect } from "react";
 import io from "socket.io-client";
 import { Peer } from "peerjs";
-import {
-  uniqueNamesGenerator,
-  adjectives,
-  animals,
-} from "unique-names-generator";
+import { useRecoilState } from "recoil";
 
-import { Context, Call } from "../types";
+import { Context } from "../types";
+import {
+  serverLoadingAtom,
+  streamAtom,
+  meAtom,
+  callAtom,
+  joinedRoomAtom,
+  callEndedAtom,
+  roomNameAtom,
+  nameAtom,
+  isAudioAtom,
+  isVideoAtom,
+  isCallerMutedAtom,
+} from "../atoms";
 
 const SocketContext = createContext<Context | null>(null);
 
@@ -20,31 +29,20 @@ const ContextProvider = ({
 }: {
   children: React.ReactNode;
 }): JSX.Element => {
-  const [serverLoading, setServerLoading] = useState(true);
-  const [stream, setStream] = useState<MediaStream>();
-  const [me, setMe] = useState("");
-  const [call, setCall] = useState<Call>({
-    isRecievedCall: false,
-    from: "",
-    name: "",
-    isVideo: true,
-  });
+  const [serverLoading, setServerLoading] = useRecoilState(serverLoadingAtom);
+  const [stream, setStream] = useRecoilState(streamAtom);
+  const [me, setMe] = useRecoilState(meAtom);
+  const [call, setCall] = useRecoilState(callAtom);
 
-  const [joinedRoom, setJoinedRoom] = useState(false);
-  const [callEnded, setCallEnded] = useState(false);
+  const [joinedRoom, setJoinedRoom] = useRecoilState(joinedRoomAtom);
+  const [callEnded, setCallEnded] = useRecoilState(callEndedAtom);
 
-  const randomRoomName = uniqueNamesGenerator({
-    dictionaries: [adjectives, animals],
-    separator: "",
-    style: "capital",
-  });
+  const [roomName, setRoomName] = useRecoilState(roomNameAtom);
+  const [name, setName] = useRecoilState(nameAtom);
 
-  const [roomName, setRoomName] = useState(randomRoomName);
-  const [name, setName] = useState("");
-
-  const [isAudio, setIsAudio] = useState(true);
-  const [isVideo, setIsVideo] = useState(true);
-  const [isCallerMuted, setIsCallerMuted] = useState(false);
+  const [isAudio, setIsAudio] = useRecoilState(isAudioAtom);
+  const [isVideo, setIsVideo] = useRecoilState(isVideoAtom);
+  const [isCallerMuted, setIsCallerMuted] = useRecoilState(isCallerMutedAtom);
 
   const myVideo = useRef<HTMLVideoElement | null>(null);
   const userVideo = useRef<HTMLVideoElement | null>(null);

--- a/client/src/context/SocketContext.tsx
+++ b/client/src/context/SocketContext.tsx
@@ -1,181 +1,22 @@
-import React, { createContext, useRef, useEffect } from "react";
-import io from "socket.io-client";
-import { Peer } from "peerjs";
-import { useRecoilState } from "recoil";
+import React, { createContext, useRef } from "react";
 
 import { Context } from "../types";
-import {
-  serverLoadingAtom,
-  streamAtom,
-  meAtom,
-  callAtom,
-  joinedRoomAtom,
-  callEndedAtom,
-  roomNameAtom,
-  nameAtom,
-  isAudioAtom,
-  isVideoAtom,
-  isCallerMutedAtom,
-} from "../atoms";
 
 const SocketContext = createContext<Context | null>(null);
-
-const socket = io(process.env.REACT_APP_SERVER_URL ?? "http://localhost:5000/");
-
-const peer = new Peer();
 
 const ContextProvider = ({
   children,
 }: {
   children: React.ReactNode;
 }): JSX.Element => {
-  const [serverLoading, setServerLoading] = useRecoilState(serverLoadingAtom);
-  const [stream, setStream] = useRecoilState(streamAtom);
-  const [me, setMe] = useRecoilState(meAtom);
-  const [call, setCall] = useRecoilState(callAtom);
-
-  const [joinedRoom, setJoinedRoom] = useRecoilState(joinedRoomAtom);
-  const [callEnded, setCallEnded] = useRecoilState(callEndedAtom);
-
-  const [roomName, setRoomName] = useRecoilState(roomNameAtom);
-  const [name, setName] = useRecoilState(nameAtom);
-
-  const [isAudio, setIsAudio] = useRecoilState(isAudioAtom);
-  const [isVideo, setIsVideo] = useRecoilState(isVideoAtom);
-  const [isCallerMuted, setIsCallerMuted] = useRecoilState(isCallerMutedAtom);
-
   const myVideo = useRef<HTMLVideoElement | null>(null);
   const userVideo = useRef<HTMLVideoElement | null>(null);
-
-  const mediaStream = useRef<MediaStream>();
-
-  useEffect(() => {
-    navigator.mediaDevices
-      .getUserMedia({ video: true, audio: true })
-      .then((currentStream) => {
-        mediaStream.current = currentStream;
-        setStream(currentStream);
-        myVideo.current!.srcObject = currentStream;
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-
-    socket.on("connection", () => setServerLoading(false));
-
-    peer.on("open", (myId) => setMe(myId));
-
-    peer.on("connection", ({ metadata }) => {
-      if ("name" in metadata) {
-        setCall((prevState) => ({
-          ...prevState,
-          name: metadata.name,
-        }));
-      } else if ("isVideo" in metadata) {
-        setCall((prevState) => ({
-          ...prevState,
-          isVideo: metadata.isVideo,
-        }));
-      }
-    });
-
-    socket.on("user-disconnected", () => {
-      setCall({
-        isRecievedCall: false,
-        from: "",
-        name: "",
-        isVideo: true,
-      });
-      userVideo.current!.srcObject = null;
-    });
-
-    peer.on("error", (err) => {
-      console.log("Error: ", err);
-    });
-  }, []);
-
-  useEffect(() => {
-    peer.on("call", (incomingCall) => {
-      setCall((prevState) => ({
-        ...prevState,
-        from: incomingCall.peer,
-        isRecievedCall: true,
-        name: incomingCall.metadata.name,
-      }));
-
-      incomingCall.answer(mediaStream.current!);
-      myVideo.current!.srcObject = mediaStream.current!;
-
-      incomingCall.on("stream", (currentStream) => {
-        userVideo.current!.srcObject = currentStream;
-        peer.connect(incomingCall.peer, { metadata: { name } });
-      });
-    });
-  }, [name]);
-
-  useEffect(() => {
-    if (myVideo.current) myVideo.current!.srcObject = stream!;
-    peer.connect(call.from, { metadata: { isVideo } });
-  }, [isVideo]);
-
-  useEffect(() => {
-    if (joinedRoom && myVideo.current) myVideo.current!.srcObject = stream!;
-  }, [joinedRoom]);
-
-  const joinRoom = (room: string): void => {
-    setJoinedRoom(true);
-
-    socket.emit("join-room", room, me);
-
-    socket.on("joined-room", () => {
-      myVideo.current!.srcObject = stream!;
-    });
-
-    socket.on("user-connected", (id) => {
-      const newCall = peer.call(id, stream!, {
-        metadata: { name },
-      });
-
-      newCall.on("stream", (currentStream) => {
-        setCall((prevState) => ({
-          ...prevState,
-          from: id,
-          isRecievedCall: true,
-        }));
-        userVideo.current!.srcObject = currentStream;
-      });
-    });
-  };
-
-  const leaveCall = (): void => {
-    setCallEnded(true);
-    window.location.reload();
-  };
 
   return (
     <SocketContext.Provider
       value={{
-        serverLoading,
-        call,
-        joinedRoom,
         myVideo,
         userVideo,
-        stream,
-        name,
-        setName,
-        roomName,
-        setRoomName,
-        callEnded,
-        me,
-        joinRoom,
-        leaveCall,
-        isAudio,
-        setIsAudio,
-        isVideo,
-        setIsVideo,
-        isCallerMuted,
-        setIsCallerMuted,
-        mediaStream,
       }}
     >
       {children}

--- a/client/src/hooks/isCallerMuted.ts
+++ b/client/src/hooks/isCallerMuted.ts
@@ -1,0 +1,11 @@
+import { useRecoilState } from "recoil";
+
+import { isCallerMutedAtom } from "../atoms";
+
+const useIsCallerMuted = () => {
+  const [isCallerMuted, setIsCallerMuted] = useRecoilState(isCallerMutedAtom);
+
+  return { isCallerMuted, setIsCallerMuted };
+};
+
+export default useIsCallerMuted;

--- a/client/src/hooks/isVideo.ts
+++ b/client/src/hooks/isVideo.ts
@@ -1,0 +1,11 @@
+import { useRecoilState } from "recoil";
+
+import { isVideoAtom } from "../atoms";
+
+const useIsVideo = () => {
+  const [isVideo, setIsVideo] = useRecoilState(isVideoAtom);
+
+  return { isVideo, setIsVideo };
+};
+
+export default useIsVideo;

--- a/client/src/hooks/useCall.ts
+++ b/client/src/hooks/useCall.ts
@@ -1,0 +1,11 @@
+import { useRecoilState } from "recoil";
+
+import { callAtom } from "../atoms";
+
+const useCall = () => {
+  const [call, setCall] = useRecoilState(callAtom);
+
+  return { call, setCall };
+};
+
+export default useCall;

--- a/client/src/hooks/useCallEnded.ts
+++ b/client/src/hooks/useCallEnded.ts
@@ -1,0 +1,11 @@
+import { useRecoilState } from "recoil";
+
+import { callEndedAtom } from "../atoms";
+
+const useCallEnded = () => {
+  const [callEnded, setCallEnded] = useRecoilState(callEndedAtom);
+
+  return { callEnded, setCallEnded };
+};
+
+export default useCallEnded;

--- a/client/src/hooks/useIsAudio.ts
+++ b/client/src/hooks/useIsAudio.ts
@@ -1,0 +1,11 @@
+import { useRecoilState } from "recoil";
+
+import { isAudioAtom } from "../atoms";
+
+const useIsAudio = () => {
+  const [isAudio, setIsAudio] = useRecoilState(isAudioAtom);
+
+  return { isAudio, setIsAudio };
+};
+
+export default useIsAudio;

--- a/client/src/hooks/useJoinedRoom.ts
+++ b/client/src/hooks/useJoinedRoom.ts
@@ -1,0 +1,11 @@
+import { useRecoilState } from "recoil";
+
+import { joinedRoomAtom } from "../atoms";
+
+const useJoinedRoom = () => {
+  const [joinedRoom, setJoinedRoom] = useRecoilState(joinedRoomAtom);
+
+  return { joinedRoom, setJoinedRoom };
+};
+
+export default useJoinedRoom;

--- a/client/src/hooks/useMe.ts
+++ b/client/src/hooks/useMe.ts
@@ -1,0 +1,10 @@
+import { useRecoilState } from "recoil";
+import { meAtom } from "../atoms";
+
+const useMe = () => {
+  const [me, setMe] = useRecoilState(meAtom);
+
+  return { me, setMe };
+};
+
+export default useMe;

--- a/client/src/hooks/useName.ts
+++ b/client/src/hooks/useName.ts
@@ -1,0 +1,11 @@
+import { useRecoilState } from "recoil";
+
+import { nameAtom } from "../atoms";
+
+const useName = () => {
+  const [name, setName] = useRecoilState(nameAtom);
+
+  return { name, setName };
+};
+
+export default useName;

--- a/client/src/hooks/useRoomName.ts
+++ b/client/src/hooks/useRoomName.ts
@@ -1,0 +1,11 @@
+import { useRecoilState } from "recoil";
+
+import { roomNameAtom } from "../atoms";
+
+const useRoomName = () => {
+  const [roomName, setRoomName] = useRecoilState(roomNameAtom);
+
+  return { roomName, setRoomName };
+};
+
+export default useRoomName;

--- a/client/src/hooks/useServerLoading.ts
+++ b/client/src/hooks/useServerLoading.ts
@@ -1,0 +1,10 @@
+import { useRecoilState } from "recoil";
+import { serverLoadingAtom } from "../atoms";
+
+const useServerLoading = () => {
+  const [serverLoading, setServerLoading] = useRecoilState(serverLoadingAtom);
+
+  return { serverLoading, setServerLoading };
+};
+
+export default useServerLoading;

--- a/client/src/hooks/useStream.ts
+++ b/client/src/hooks/useStream.ts
@@ -1,0 +1,11 @@
+import { useRecoilState } from "recoil";
+
+import { streamAtom } from "../atoms";
+
+const useStream = () => {
+  const [stream, setStream] = useRecoilState(streamAtom);
+
+  return { stream, setStream };
+};
+
+export default useStream;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,13 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { RecoilRoot } from "recoil";
 
 import App from "./App";
 import { ContextProvider } from "./context/SocketContext";
 import "./styles.css";
 
 ReactDOM.render(
-  <ContextProvider>
-    <App />
-  </ContextProvider>,
+  <RecoilRoot>
+    <ContextProvider>
+      <App />
+    </ContextProvider>
+  </RecoilRoot>,
   document.getElementById("root")
 );

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -6,25 +6,6 @@ export interface Call {
 }
 
 export interface Context {
-  serverLoading: boolean;
-  call: Call;
-  joinedRoom: boolean;
   myVideo: React.MutableRefObject<HTMLVideoElement | null>;
   userVideo: React.MutableRefObject<HTMLVideoElement | null>;
-  stream: MediaStream | undefined;
-  name: string;
-  setName: React.Dispatch<React.SetStateAction<string>>;
-  roomName: string;
-  setRoomName: React.Dispatch<React.SetStateAction<string>>;
-  callEnded: boolean;
-  me: string;
-  joinRoom: (id: string) => void;
-  leaveCall: () => void;
-  isAudio: boolean;
-  setIsAudio: React.Dispatch<React.SetStateAction<boolean>>;
-  isVideo: boolean;
-  setIsVideo: React.Dispatch<React.SetStateAction<boolean>>;
-  isCallerMuted: boolean;
-  setIsCallerMuted: React.Dispatch<React.SetStateAction<boolean>>;
-  mediaStream: React.MutableRefObject<MediaStream | undefined>;
 }

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,0 +1,8 @@
+import io from "socket.io-client";
+import { Peer } from "peerjs";
+
+export const socket = io(
+  process.env.REACT_APP_SERVER_URL ?? "http://localhost:5000/"
+);
+
+export const peer = new Peer();


### PR DESCRIPTION
Since we are using Context API for global states, everytime any state changes the whole app re-renders. Using `recoil` will avoid those unnecessary re-renders.